### PR TITLE
Additional bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 # Kubernetes Client
-[![Build Status](https://api.travis-ci.org/maclof/kubernetes-client.svg?branch=master)](https://travis-ci.org/maclof/kubernetes-client)
+
+[![Build Status](https://app.travis-ci.com/maclof/kubernetes-client.svg?branch=master)](https://app.travis-ci.com/maclof/kubernetes-client)
 
 A PHP client for managing a Kubernetes cluster.
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,16 +1,11 @@
 <?php namespace Maclof\Kubernetes;
 
 use Exception;
-use Http\Client\Common\HttpMethodsClientInterface;
 use InvalidArgumentException;
 use BadMethodCallException;
+use Maclof\Kubernetes\Exceptions\ApiServerException;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException as YamlParseException;
-
-// use GuzzleHttp\Client as GuzzleClient;
-// use GuzzleHttp\Exception\ClientException as GuzzleClientException;
-// use GuzzleHttp\Exception\ServerException;
-// use GuzzleHttp\Psr7\Stream;
 
 use Http\Client\HttpClient;
 use Http\Client\Common\HttpMethodsClient;
@@ -22,7 +17,6 @@ use Http\Discovery\MessageFactoryDiscovery as HttpMessageFactoryDiscovery;
 use React\EventLoop\Factory as ReactFactory;
 use React\Socket\Connector as ReactSocketConnector;
 use Ratchet\Client\Connector as WebSocketConnector;
-use Maclof\Kubernetes\Exceptions\ApiServerException;
 use Maclof\Kubernetes\Repositories\CertificateRepository;
 use Maclof\Kubernetes\Exceptions\BadRequestException;
 use Maclof\Kubernetes\Repositories\ConfigMapRepository;
@@ -44,7 +38,6 @@ use Maclof\Kubernetes\Repositories\ReplicationControllerRepository;
 use Maclof\Kubernetes\Repositories\SecretRepository;
 use Maclof\Kubernetes\Repositories\ServiceRepository;
 use Maclof\Kubernetes\Repositories\NamespaceRepository;
-use Maclof\Kubernetes\Models\PersistentVolume;
 
 /**
  * @method NodeRepository nodes()
@@ -163,7 +156,7 @@ class Client
 	 * @param \Http\Client\HttpClient|null $httpClient
 	 * @param \Http\Message\RequestFactory $httpRequestFactory
 	 */
-	public function __construct(array $options = [], RepositoryRegistry $repositoryRegistry = null, HttpClient $httpClient = null, HttpRequestFactory $httpRequestFactory = null)
+	public function __construct(array $options = [], RepositoryRegistry $repositoryRegistry = null, $httpClient = null, HttpRequestFactory $httpRequestFactory = null)
 	{
 		$this->setOptions($options);
 		$this->classRegistry = $repositoryRegistry ?: new RepositoryRegistry();
@@ -210,28 +203,35 @@ class Client
 	/**
 	 * Parse a kubeconfig.
 	 * 
-	 * @param  string $content
+	 * @param  string|array $content Mixed type, based on the second input argument
 	 * @param  string $contentType
 	 * @return array
 	 * @throws \InvalidArgumentException
 	 */
 	public static function parseKubeconfig($content, $contentType = 'yaml')
 	{
-		if ($contentType == 'array') {
+		if ($contentType === 'array') {
 			if (!is_array($content)) {
 				throw new InvalidArgumentException('Kubeconfig is not an array.');
 			}
-		} elseif ($contentType == 'json') {
+		} elseif ($contentType === 'json') {
 			if (!is_string($content)) {
 				throw new InvalidArgumentException('Kubeconfig is not a string.');
 			}
 
-			try {
-				$content = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
-			} catch (JsonException $e) {
-				throw new InvalidArgumentException('Failed to parse JSON encoded Kubeconfig: ' . $e->getMessage(), 0, $e);
+			if (defined('JSON_THROW_ON_ERROR')) {
+				try {
+					$content = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+				} catch (\JsonException $e) {
+					throw new InvalidArgumentException('Failed to parse JSON encoded Kubeconfig: ' . $e->getMessage(), 0, $e);
+				}
+			} else {
+				$content = json_decode($content, true, 512);
+				if ($content === false || $content === null) {
+					throw new InvalidArgumentException('Failed to parse JSON encoded Kubeconfig.');
+				}
 			}
-		} elseif ($contentType == 'yaml') {
+		} elseif ($contentType === 'yaml') {
 			if (!is_string($content)) {
 				throw new InvalidArgumentException('Kubeconfig is not a string.');
 			}
@@ -241,7 +241,7 @@ class Client
 				throw new InvalidArgumentException('Failed to parse YAML encoded Kubeconfig: ' . $e->getMessage(), 0, $e);
 			}
 		} else {
-			throw new InvalidArgumentException('Invalid Kubeconfig content type: ' . $contnetType);
+			throw new InvalidArgumentException('Invalid Kubeconfig content type: ' . $contentType);
 		}
 
 		// TODO: support token auth?
@@ -252,7 +252,7 @@ class Client
 				$contexts[$context['name']] = $context['context'];
 			}
 		}
-		if (count($contexts) == 0) {
+		if (count($contexts) === 0) {
 			throw new InvalidArgumentException('Kubeconfig parse error - No contexts are defined.');
 		}
 
@@ -373,13 +373,13 @@ class Client
 	/**
 	 * Set patch header
 	 *
-	 * @param patch type
+	 * @param string patch type
 	 */
 	public function setPatchType($patchType = "strategic")
 	{
-		if ($patchType == "merge") {
+		if ($patchType === "merge") {
 			$this->patchHeaders = ['Content-Type' => 'application/merge-patch+json'];
-		} elseif ($patchType == "json") {
+		} elseif ($patchType === "json") {
 			$this->patchHeaders = ['Content-Type' => 'application/json-patch+json'];
 		} else {
 			$this->patchHeaders = ['Content-Type' => 'application/strategic-merge-patch+json'];
@@ -433,6 +433,17 @@ class Client
 
 			$response = $this->httpClient->send($method, $requestUrl, $headers, $body);
 
+			// Error Handling
+			if ($response->getStatusCode() >= 500) {
+				$msg = substr((string) $response->getBody(), 0, 1200); // Limit maximum chars
+				throw new ApiServerException("Server responded with 500 Error: " . $msg, 500);
+			}
+
+			if (in_array($response->getStatusCode(), [401, 403], true)) {
+				$msg = substr((string) $response->getBody(), 0, 1200); // Limit maximum chars
+				throw new ApiServerException("Authentication Exception: " . $msg, $response->getStatusCode());
+			}
+
 			if (!empty($options['stream'])) {
 				return $response;
 			}
@@ -446,11 +457,11 @@ class Client
 
 			$responseBody = (string) $response->getBody();
 
-			if (in_array('application/json', $response->getHeader('Content-Type'))) {
+			if (in_array('application/json', $response->getHeader('Content-Type'), true)) {
 				$jsonResponse = json_decode($responseBody, true);
 
 				if ($this->isUpgradeRequestRequired($jsonResponse)) {
-					return $this->sendUpgradeRequest($requestUri, $query);
+					return $this->sendUpgradeRequest($requestUrl, $query);
 				}
 			}
 
@@ -466,7 +477,7 @@ class Client
 	 */
 	protected function isUpgradeRequestRequired(array $response)
 	{
-		return $response['code'] == 400 && $response['status'] == 'Failure' && $response['message'] == 'Upgrade request required';
+		return $response['code'] == 400 && $response['status'] === 'Failure' && $response['message'] === 'Upgrade request required';
 	}
 
 	/**
@@ -479,7 +490,7 @@ class Client
 	protected function sendUpgradeRequest($requestUri, array $query)
 	{
 		$fullUrl = $this->master .'/' . $requestUri . '?' . implode('&', $this->parseQueryParams($query));
-		if (parse_url($fullUrl, PHP_URL_SCHEME) == 'https') {
+		if (parse_url($fullUrl, PHP_URL_SCHEME) === 'https') {
 			$fullUrl = str_replace('https://', 'wss://', $fullUrl);
 		} else {
 			$fullUrl = str_replace('http://', 'ws://', $fullUrl);
@@ -612,7 +623,7 @@ class Client
 		if (isset($this->classRegistry[$name])) {
 			$class = $this->classRegistry[$name];
 
-			return isset($this->classInstances[$name]) ? $this->classInstances[$name] : new $class($this);
+			return $this->classInstances[$name] ?? new $class($this);
 		}
 
 		throw new BadMethodCallException('No client methods exist with the name: ' . $name);

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ use Exception;
 use InvalidArgumentException;
 use BadMethodCallException;
 use Maclof\Kubernetes\Exceptions\ApiServerException;
+use Psr\Http\Client\ClientInterface;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException as YamlParseException;
 
@@ -153,10 +154,10 @@ class Client
 	 *
 	 * @param array $options
 	 * @param \Maclof\Kubernetes\RepositoryRegistry|null $repositoryRegistry
-	 * @param \Http\Client\HttpClient|null $httpClient
+	 * @param ClientInterface|null $httpClient Some client implementing PSR HTTP ClientInterface
 	 * @param \Http\Message\RequestFactory $httpRequestFactory
 	 */
-	public function __construct(array $options = [], RepositoryRegistry $repositoryRegistry = null, $httpClient = null, HttpRequestFactory $httpRequestFactory = null)
+	public function __construct(array $options = [], RepositoryRegistry $repositoryRegistry = null, ClientInterface $httpClient = null, HttpRequestFactory $httpRequestFactory = null)
 	{
 		$this->setOptions($options);
 		$this->classRegistry = $repositoryRegistry ?: new RepositoryRegistry();

--- a/src/Client.php
+++ b/src/Client.php
@@ -263,7 +263,7 @@ class Client
 				$clusters[$cluster['name']] = $cluster['cluster'];
 			}
 		}
-		if (count($clusters) == 0) {
+		if (count($clusters) === 0) {
 			throw new InvalidArgumentException('Kubeconfig parse error - No clusters are defined.');
 		}
 
@@ -273,7 +273,7 @@ class Client
 				$users[$user['name']] = $user['user'];
 			}
 		}
-		if (count($users) == 0) {
+		if (count($users) === 0) {
 			throw new InvalidArgumentException('Kubeconfig parse error - No users are defined.');
 		}
 

--- a/src/Exceptions/ApiServerException.php
+++ b/src/Exceptions/ApiServerException.php
@@ -1,0 +1,5 @@
+<?php namespace Maclof\Kubernetes\Exceptions;
+
+class ApiServerException extends \Exception
+{
+}


### PR DESCRIPTION
## Minor tweaks

- Fixed build svg badge to point to travis-ci.com
- Changed == to === where safe to do so (string comparisons)
- Changed `isset($a) ? $a : $something` to `($a ?? $something)` (valid in this library's minimum PHP requirement: 7.1)
**- Fixed some typos in variable names that actually would have caused errors if those code paths were hit**

## Make proper argument typehint for http client interface

This library's `Client` constructor has a third argument, currently `Http\Client\HttpClient $httpClient = null ` but I don't think that is quite correct; it should be `\Psr\Http\Client\ClientInterface` to make it fully compatible. There is only one method on `ClientInterface` and that is `sendRequest` so by doing this, we can easily pass in `\GuzzleHttp\Client` if we want, or some other concrete class. Let me know if I'm not mistaken in this.

## Added some error handling

if you make an API request and the server responds with 500 (Server Error) this library will currently ignore the error, returning the string response back to the caller, which could be PodRepository for example, which would then cause a weird "Array index `items` doesn't exist".

Similarly, if the user has bad credentials we'll get a 401 or 403 response but again it will be passed along and might cause an error, might not. One big problem with this is a request where the library doesn't need to parse the response, such as a DELETE POD operation. The code will return cleanly and the user might think the delete succeeded!

To fix this I added some checks for 401/403/500 and throw an `ApiServerException`, a new class unique to this library. 

## JSON Throw on Error

At some point someone added `JSON_THROW_ON_ERROR` feature to a json_decode, however this constant and feature only exists on PHP 7.3 and up, but it looked like this library is supporting PHP 7.1 and up. We could bump up the minimum requirement to PHP 7.3, but another way I implemented here was to check if the constant is defined or not, and handle it slightly differently depending.